### PR TITLE
Delete stale branches older than 7 days

### DIFF
--- a/.github/workflows/delete-old-branches.yml
+++ b/.github/workflows/delete-old-branches.yml
@@ -16,5 +16,4 @@ jobs:
           repo_token: ${{ github.token }}
           date: '7 days ago'
           default_branches: main,master,staging
-          dry_run: true
           exclude_open_pr_branches: true

--- a/.github/workflows/delete-old-branches.yml
+++ b/.github/workflows/delete-old-branches.yml
@@ -1,0 +1,39 @@
+name: Delete old branches
+on:
+  schedule:
+    - cron: "0 0 * * *"  # Runs every day at midnight (UTC)
+
+jobs:
+  list-stale-branches:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Fetch All Branches
+        run: git fetch --prune --all
+
+      - name: Delete branches older than 7 days
+        run: |
+          # Get the current date in Unix timestamp format
+          current_date=$(date +%s)
+          
+          # Get the list of remote branches and iterate over each branch
+          git branch -r | while read branch; do
+            # Extract the branch name from the full reference (e.g., "origin/branch-name")
+            branch_name=${branch#"origin/"}
+          
+            # Get the last commit date of the branch in Unix timestamp format
+            last_commit_date=$(git show -s --format=%ct "origin/$branch_name")
+          
+            # Calculate the time difference in seconds between the current date and last commit date
+            time_difference=$((current_date - last_commit_date))
+          
+            # Define the threshold in seconds (7 days: 7 days * 24 hours/day * 60 minutes/hour * 60 seconds/minute)
+            threshold=$((7 * 24 * 60 * 60))
+          
+            # Check if the branch is stale (not updated in the last 7 days) and list it if so
+            if [ "$time_difference" -gt "$threshold" ]; then
+              echo "Stale branch: $branch_name"
+            fi
+          done

--- a/.github/workflows/delete-old-branches.yml
+++ b/.github/workflows/delete-old-branches.yml
@@ -6,7 +6,7 @@ name: Delete old branches
 on: [push]
 
 jobs:
-  list-stale-branches:
+  delete-old-branches:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/.github/workflows/delete-old-branches.yml
+++ b/.github/workflows/delete-old-branches.yml
@@ -7,42 +7,16 @@ on: [push]
 
 jobs:
   delete-old-branches:
+    name: Delete old branches
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repository
+      - name: Checkout repository
         uses: actions/checkout@v2
-
-      - name: Fetch All Branches
-        run: git fetch --prune --all
-
-      - name: Delete branches older than 7 days
-        run: |
-          # Get the current date in Unix timestamp format
-          current_date=$(date +%s)
-          
-          # Get the list of remote branches and iterate over each branch
-          git branch -r | while read branch; do
-            # Extract the branch name from the full reference (e.g., "origin/branch-name")
-            branch_name=${branch#"origin/"}
-          
-            # Skip the 'master' branch
-            if [ "$branch_name" = "master" ]; then
-              continue
-            fi
-          
-            # Get the last commit date of the branch in Unix timestamp format
-            last_commit_date=$(git show -s --format=%ct "origin/$branch_name")
-          
-            # Calculate the time difference in seconds between the current date and last commit date
-            time_difference=$((current_date - last_commit_date))
-          
-            # Define the threshold in seconds (7 days: 7 days * 24 hours/day * 60 minutes/hour * 60 seconds/minute)
-            threshold=$((7 * 24 * 60 * 60))
-          
-            # Check if the branch is stale (not updated in the last 7 days) and list it if so
-            if [ "$time_difference" -gt "$threshold" ]; then
-              echo "Stale branch: $branch_name"
-              # git push --delete origin "$branch_name"
-              # git branch -d "$branch_name"
-            fi
-          done
+      - name: Run delete-old-branches-action
+        uses: beatlabs/delete-old-branches-action@v0.0.10
+        with:
+          repo_token: ${{ github.token }}
+          date: '7 days ago'
+          default_branches: main,master,staging
+          dry_run: true
+          exclude_open_pr_branches: true

--- a/.github/workflows/delete-old-branches.yml
+++ b/.github/workflows/delete-old-branches.yml
@@ -25,6 +25,11 @@ jobs:
             # Extract the branch name from the full reference (e.g., "origin/branch-name")
             branch_name=${branch#"origin/"}
           
+            # Skip the 'master' branch
+            if [ "$branch_name" = "master" ]; then
+              continue
+            fi
+          
             # Get the last commit date of the branch in Unix timestamp format
             last_commit_date=$(git show -s --format=%ct "origin/$branch_name")
           

--- a/.github/workflows/delete-old-branches.yml
+++ b/.github/workflows/delete-old-branches.yml
@@ -42,5 +42,7 @@ jobs:
             # Check if the branch is stale (not updated in the last 7 days) and list it if so
             if [ "$time_difference" -gt "$threshold" ]; then
               echo "Stale branch: $branch_name"
+              # git push --delete origin "$branch_name"
+              # git branch -d "$branch_name"
             fi
           done

--- a/.github/workflows/delete-old-branches.yml
+++ b/.github/workflows/delete-old-branches.yml
@@ -1,9 +1,7 @@
 name: Delete old branches
-#on:
-#  schedule:
-#    - cron: "0 0 * * *"  # Runs every day at midnight (UTC)
-
-on: [push]
+on:
+  schedule:
+    - cron: "0 0 * * *"  # Runs every day at midnight (UTC)
 
 jobs:
   delete-old-branches:

--- a/.github/workflows/delete-old-branches.yml
+++ b/.github/workflows/delete-old-branches.yml
@@ -1,7 +1,9 @@
 name: Delete old branches
-on:
-  schedule:
-    - cron: "0 0 * * *"  # Runs every day at midnight (UTC)
+#on:
+#  schedule:
+#    - cron: "0 0 * * *"  # Runs every day at midnight (UTC)
+
+on: [push]
 
 jobs:
   list-stale-branches:


### PR DESCRIPTION
This is another attempt to delete stale branches older than 7 days.
This github action is based on https://github.com/beatlabs/delete-old-branches-action.
It will run at midnight and will delete branches without changes for the past 7 days, excluding main, master and staging branches. It will also exclude tags.

Validated that master and staging branches are not affected, check the logs:
```
Deleting: APICS-1023/legacy-webhook
To recreate run: git branch 'APICS-1023/legacy-webhook' 'c80551040e9de5ea1d86248cd324a3967b373f8b'
dry-run mode. Nothing changed!
Deleting: APICS-1136/ts-sdk-eu-endpoint
To recreate run: git branch 'APICS-1136/ts-sdk-eu-endpoint' '7081105d577b8394638a6c6a9a8794043b9034e4'
dry-run mode. Nothing changed!
Deleting: APICS-550/reorg-go-sdk
To recreate run: git branch 'APICS-550/reorg-go-sdk' 'e6f239cbb92a65a4729ff6db503e77b9e2a12203'
dry-run mode. Nothing changed!
Deleting: APICS-610/transformations-v1-promotion
To recreate run: git branch 'APICS-610/transformations-v1-promotion' 'e0f8b9bb73d5563f468117c7452b0c62ac42468c'
dry-run mode. Nothing changed!
Deleting: APICS-611/mvn-publish-on-changed-pom
To recreate run: git branch 'APICS-611/mvn-publish-on-changed-pom' 'd6801126ee60f02063ce8c24d2a0645cb7ebe03b'
dry-run mode. Nothing changed!
Deleting: APICS-618/tar-sdks
To recreate run: git branch 'APICS-618/tar-sdks' '2f5f11e867a86da5bf8ecf5cb85b7f2068026cfd'
dry-run mode. Nothing changed!
Deleting: APICS-630/earlier-rate-limit
To recreate run: git branch 'APICS-630/earlier-rate-limit' '04bacb2073ee3ed4c3cb508ae72884fead9ba26d'
dry-run mode. Nothing changed!
Deleting: APICS-632/retry-autodeploy
To recreate run: git branch 'APICS-632/retry-autodeploy' 'b401ebc3cb4f5816a3b64a0e10a126f4f05ed32b'
dry-run mode. Nothing changed!
Deleting: APICS-653/papi-docs-sdk-ts
To recreate run: git branch 'APICS-653/papi-docs-sdk-ts' '435725e9d2c02080bdb9609c3dba4583c466e836'
dry-run mode. Nothing changed!
Deleting: APICS-656/java-docs-samples
To recreate run: git branch 'APICS-656/java-docs-samples' 'c3b2218f8fcb1cd0505f356084de92350280f529'
dry-run mode. Nothing changed!
Deleting: APICS-737/eventdeliverymetrics.get
To recreate run: git branch 'APICS-737/eventdeliverymetrics.get' '036cf003e6bfebeb9efc2a9482daa3e194c5dcbe'
dry-run mode. Nothing changed!
Deleting: APICS-739/EDM.List
To recreate run: git branch 'APICS-739/EDM.List' '78f06acf9a1b7219626a1a413d1bf95febdf2154'
dry-run mode. Nothing changed!
Deleting: APICS-763/Invites.List
To recreate run: git branch 'APICS-763/Invites.List' '7562b5a94037031004933f785efed78bb4c45d61'
dry-run mode. Nothing changed!
Deleting: APICS-831/trackingplans.get
To recreate run: git branch 'APICS-831/trackingplans.get' '9a23501e9ab9fda111f9f342ac9e8c414415f1be'
dry-run mode. Nothing changed!
Deleting: APICS-837/traceid-debugging
To recreate run: git branch 'APICS-837/traceid-debugging' '05612706844d37278790a2f2b9fcd4e6e62c90d9'
dry-run mode. Nothing changed!
Deleting: APICS-838/source-events-output
To recreate run: git branch 'APICS-838/source-events-output' '95fadd1f822d058782b260004a8604862140a218'
dry-run mode. Nothing changed!
Deleting: APICS-873/fix-param-to-pair
To recreate run: git branch 'APICS-873/fix-param-to-pair' '4d2a295633c1be86d3b4948ddb68d9e4c48b70f9'
dry-run mode. Nothing changed!
Deleting: APICS-922/delete-dest-new
To recreate run: git branch 'APICS-922/delete-dest-new' '3168b4d977c6817d6ce1e930f596ecf6bb285db9'
dry-run mode. Nothing changed!
Deleting: APICS-927/dest-list-pagination
To recreate run: git branch 'APICS-927/dest-list-pagination' 'be2a6346486a48bcca7049b6126594feb30814a3'
dry-run mode. Nothing changed!
Deleting: APICS-982/dest-filters-wording
To recreate run: git branch 'APICS-982/dest-filters-wording' '5b5d999d4347592a8c808a24666adf9950e8642d'
dry-run mode. Nothing changed!
Deleting: DESTINATION_METADATA_REGIONAL
To recreate run: git branch 'DESTINATION_METADATA_REGIONAL' '9135dbc9f4a04c2668d41f147b11a7ea5c828a42'
dry-run mode. Nothing changed!
Deleting: DM-2611/ppanda_increase_timeout
To recreate run: git branch 'DM-2611/ppanda_increase_timeout' '9f4c284a3f45a73bf4d4e10025e469719bcb1f7a'
dry-run mode. Nothing changed!
Deleting: FUNK-668-webhook
To recreate run: git branch 'FUNK-668-webhook' '5edebae5c9d06c88b5fcb1f49cb64f7f67a61d15'
dry-run mode. Nothing changed!
Deleting: FUNK-792/papi-doc-update
To recreate run: git branch 'FUNK-792/papi-doc-update' '9066b266f018991c5490ad999f70ab06babcb8ca'
dry-run mode. Nothing changed!
Deleting: JIRA-2396/update-regulation-test
To recreate run: git branch 'JIRA-2396/update-regulation-test' 'f3fdd4a9856eabd36f2a5b58e3d526cb353ab3bc'
dry-run mode. Nothing changed!
Deleting: PIW-1289/selective-sync
To recreate run: git branch 'PIW-1289/selective-sync' 'f[617](https://github.com/segmentio/public-api-sdk-java/actions/runs/5617063292/job/15220512971#step:4:618)382d33fe328c8be4a22fbe233e7265ca833d'
dry-run mode. Nothing changed!
Deleting: PIW-1289/update-schema
To recreate run: git branch 'PIW-1289/update-schema' '0deed8b02d905af7cc888e8d9482feb1c1eb1a90'
dry-run mode. Nothing changed!
Deleting: dd-trace
To recreate run: git branch 'dd-trace' '88fe30abf4a67b8d6d55655c8ea923312490e9d3'
dry-run mode. Nothing changed!
Deleting: deploy-client-messaging
To recreate run: git branch 'deploy-client-messaging' '6f2ce8ccfa72ced1c3d9d2c54c2f1b125c2cbc9b'
dry-run mode. Nothing changed!
Deleting: install-instructions
To recreate run: git branch 'install-instructions' '50f80bbe4a23cc40523a389934d9b6ac762e[629](https://github.com/segmentio/public-api-sdk-java/actions/runs/5617063292/job/15220512971#step:4:630)2'
dry-run mode. Nothing changed!
branch: master is a default branch. Won't delete it
Deleting: piw-1205
To recreate run: git branch 'piw-1205' 'beb38f9df27442b6823c8a49f7b93988a9a2d[632](https://github.com/segmentio/public-api-sdk-java/actions/runs/5617063292/job/15220512971#step:4:633)'
dry-run mode. Nothing changed!
Deleting: piw-1206
To recreate run: git branch 'piw-1206' '38b1250d28b18a81d5f38485ee5c64e49257596e'
dry-run mode. Nothing changed!
Deleting: piw-1207
To recreate run: git branch 'piw-1207' 'f70260fdb9593e77ce4a0c4c9667033a3f5f3a24'
dry-run mode. Nothing changed!
Deleting: piw-1208
To recreate run: git branch 'piw-1208' 'd5d9034d29b9aacaff6a353c51bd755a285df480'
dry-run mode. Nothing changed!
Deleting: sdk-user-agent
To recreate run: git branch 'sdk-user-agent' '8f2b3f202a9e73d00ef181ea999e2b516f338ea9'
dry-run mode. Nothing changed!
branch: snyk-upgrade-0c82d500c481e02c718ef7235961b769 has an open pull request and won't be deleted
branch: snyk-upgrade-45d0a403aa3fbc0e3e3b7cd23c9d84c6 has an open pull request and won't be deleted
branch: snyk-upgrade-b6d75351e45f422ad2315b8b1e98dbae has an open pull request and won't be deleted
branch: staging is a default branch. Won't delete it
Deleting: stat-no-diffs
To recreate run: git branch 'stat-no-diffs' '4b271f3877f944b0c46e94e20ef3f43097b66fb7'
dry-run mode. Nothing changed!
Deleting: upgrade-autobahn-10953b6
To recreate run: git branch 'upgrade-autobahn-10953b6' '3146a21af9aa1a5f66f6e29e56cd5bedd197964b'
dry-run mode. Nothing changed!
Deleting: upgrade-autobahn-3bd529c
To recreate run: git branch 'upgrade-autobahn-3bd529c' '7a29a3e8ce0b924cae9b570dbb153466859cf8b0'
dry-run mode. Nothing changed!
Deleting: versions-endpoints
To recreate run: git branch 'versions-endpoints' '49e4f9760[723](https://github.com/segmentio/public-api-sdk-java/actions/runs/5617063292/job/15220512971#step:4:724)508f15d24128d3cf0c9a861d063f'
dry-run mode. Nothing changed!
```