### PR TITLE
ci: use ubuntu-latest-large runner

### DIFF
--- a/.github/workflows/delete-old-branches.yml
+++ b/.github/workflows/delete-old-branches.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   delete-old-branches:
     name: Delete old branches
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     permissions:
       contents: write
       pull-requests: read


### PR DESCRIPTION
- Switch from ubuntu-latest to ubuntu-latest-large
- Fixes builds hanging on "Waiting for a runner to pick up this job..." — the enterprise doesn't schedule ubuntu-latest jobs